### PR TITLE
[Bug fix] Fix zero  vector<u8> 

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@metamask/eslint-config": "^4.0.0",
-    "@starcoin/starcoin": "^1.8.0",
+    "@starcoin/starcoin": "^2.1.6",
     "@starcoin/starmask-onboarding": "^1.0.0",
     "clean-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^6.0.2",


### PR DESCRIPTION
使用 `starcoin.js: 2.1.6` 已经修复此问题
 fix #13 